### PR TITLE
Update install links for user fork

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -4,9 +4,9 @@
 
 <br>
 
-<a href="https://github.com/Azumi67/Wireguard-panel/blob/main/README-en.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">English</a>
+<a href="https://github.com/arianking8585/Wireguard-panel/blob/main/README-en.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">English</a>
 <span style="font-size: 16px; color: #555;">•</span>
-<a href="https://github.com/Azumi67/Wireguard-panel/blob/main/README.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">Persian</a>
+<a href="https://github.com/arianking8585/Wireguard-panel/blob/main/README.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">Persian</a>
 
 </div>
 
@@ -330,7 +330,7 @@ systemctl stop telegram-bot-en
 - Run the script first
  
 ```
-sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/Azumi67/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
+sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/arianking8585/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
 ```
 
 
@@ -394,7 +394,7 @@ sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL 
 ```
 sudo apt update && sudo apt install git -y
 cd /usr/local/bin
-sudo git clone https://github.com/Azumi67/Wireguard-panel.git
+sudo git clone https://github.com/arianking8585/Wireguard-panel.git
 cd /usr/local/bin/Wireguard-panel
 
 sudo apt install -y python3 python3-pip python3-venv git redis nftables iptables wireguard-tools iproute2 \
@@ -621,7 +621,7 @@ WantedBy=multi-user.target
 - Main script to install & update
 
 ```
-sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/Azumi67/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
+sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/arianking8585/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <br>
 
-<a href="https://github.com/Azumi67/Wireguard-panel/blob/main/README-en.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">English</a>
+<a href="https://github.com/arianking8585/Wireguard-panel/blob/main/README-en.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">English</a>
 <span style="font-size: 16px; color: #555;">•</span>
-<a href="https://github.com/Azumi67/Wireguard-panel/blob/main/README.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">فارسی</a>
+<a href="https://github.com/arianking8585/Wireguard-panel/blob/main/README.md" style="font-size: 16px; font-weight: bold; text-decoration: none; color: #0078d7;">فارسی</a>
 
 </div>
 
@@ -48,7 +48,7 @@
 - بعدا فایل secret.key هم در قسمت manual backups قرار میدهم. در حال حاضر short links ها به بک اپ manual اضافه شده است
 - دستور فایل bash هم در قسمت پایین قرار میدهم
 ```
-bash <(curl -Ls https://raw.githubusercontent.com/Azumi67/Wireguard-panel/refs/heads/main/short_link.sh --ipv4)
+bash <(curl -Ls https://raw.githubusercontent.com/arianking8585/Wireguard-panel/refs/heads/main/short_link.sh --ipv4)
 
 ```
 - توجه کنید که قبل از استفاده از ورژن جدید، انرا در سروری دیگر تست نمایید تا با مشکلاتی روبرو نشوید. نحوه تبدیل کردن لینک کوتاه سرور قبل در سرور جدید را در قسمت بالا توضیح دادم.
@@ -426,7 +426,7 @@ systemctl stop telegram-bot-en
 - اجرای اسکریپت دانلود
  
 ```
-sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/Azumi67/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
+sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/arianking8585/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
 ```
 
 
@@ -491,7 +491,7 @@ sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL 
 ```
 sudo apt update && sudo apt install git -y
 cd /usr/local/bin
-sudo git clone https://github.com/Azumi67/Wireguard-panel.git
+sudo git clone https://github.com/arianking8585/Wireguard-panel.git
 cd /usr/local/bin/Wireguard-panel
 
 sudo apt install -y python3 python3-pip python3-venv git redis nftables iptables wireguard-tools iproute2 \
@@ -725,7 +725,7 @@ WantedBy=multi-user.target
 
 
 ```
-sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/Azumi67/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
+sudo apt update && sudo apt install -y curl && apt install git -y && curl -fsSL -o download.sh https://raw.githubusercontent.com/arianking8585/Wireguard-panel/refs/heads/main/download.sh && bash download.sh
 
 ```
 

--- a/download.sh
+++ b/download.sh
@@ -17,7 +17,7 @@ prompt_action() {
 }
 
 update_files() {
-    REPO_URL="https://github.com/Azumi67/Wireguard-panel.git"
+    REPO_URL="https://github.com/arianking8585/Wireguard-panel.git"
     TMP_DIR="/tmp/wireguard-panel-update"
     SCRIPT_DIR="/usr/local/bin/Wireguard-panel"
 
@@ -221,7 +221,7 @@ uninstall_mnu() {
 reinstall() {
     uninstall_mnu
     TARGET_DIR="/usr/local/bin/Wireguard-panel"
-    REPO_URL="https://github.com/Azumi67/Wireguard-panel.git"
+    REPO_URL="https://github.com/arianking8585/Wireguard-panel.git"
 
     echo -e "${LIGHT_YELLOW}Reinstalling... Removing old setup directory.${NC}"
     sudo rm -rf "$TARGET_DIR"

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -44,7 +44,7 @@ logo=$(cat << "EOF"
       \033[96m   /' /\  \   \033[1;94m  /  ___/ \033[1;92m(:  |  | . )\033[1;93m /\   \/.    |\033[1;91m |:  |   
      \033[96m   //  __'  \  \033[1;94m //  \__  \033[1;92m \  \__/  / \033[1;93m|: \.        | \033[1;91m|.  |   
       \033[96m  /  /  \   \ \033[1;94m(:   / "\ \033[1;92m /\  __  /\ \033[1;93m|.  \    /:  |\033[1;91m /\  |\ 
-      \033[96m(___/    \___) \033[1;94m\_______)\033[1;92m(__________)\033[1;93m|___|\__/|___|\033[1;91m(__\_|_) \033[1;92mAuthor: github.com/Azumi67  \033[0m         
+      \033[96m(___/    \___) \033[1;94m\_______)\033[1;92m(__________)\033[1;93m|___|\__/|___|\033[1;91m(__\_|_) \033[1;92mAuthor: github.com/arianking8585  \033[0m
 EOF
 )
 display_logo() {
@@ -298,7 +298,7 @@ select_stuff() {
 
 update_files() {
     install_newupdate
-    REPO_URL="https://github.com/Azumi67/Wireguard-panel.git"
+    REPO_URL="https://github.com/arianking8585/Wireguard-panel.git"
     TMP_DIR="/tmp/wireguard-panel-update"
     SCRIPT_DIR="/usr/local/bin/Wireguard-panel"
 

--- a/src/templates/login-fa.html
+++ b/src/templates/login-fa.html
@@ -29,7 +29,7 @@
         <div class="image-container">
             <img src="{{ url_for('static', filename='images/ringo_high_quality.png') }}" alt="تصویر ورود">
             <div class="footer">
-                <p>پنل وایرگارد توسط <a href="https://github.com/Azumi67" target="_blank">آزومی</a></p>
+                <p>پنل وایرگارد توسط <a href="https://github.com/arianking8585" target="_blank">arianking8585</a></p>
             </div>
         </div>
         <form method="POST" action="/set-language" id="language-form">

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -35,7 +35,7 @@
         <div class="image-container">
             <img src="{{ url_for('static', filename='images/ringo_high_quality.png') }}" alt="Login Illustration">
             <div class="footer">
-                <p>Wireguard Panel by <a href="https://github.com/Azumi67" target="_blank">Azumi</a></p>
+                <p>Wireguard Panel by <a href="https://github.com/arianking8585" target="_blank">arianking8585</a></p>
             </div>
         </div>
         <form method="POST" action="/set-language" id="language-form">

--- a/src/templates/register-fa.html
+++ b/src/templates/register-fa.html
@@ -45,7 +45,7 @@
     </div>
 
     <div class="footer">
-        <p>پنل وایرگارد توسط <a href="https://github.com/Azumi67" target="_blank">آزومی</a></p>
+        <p>پنل وایرگارد توسط <a href="https://github.com/arianking8585" target="_blank">arianking8585</a></p>
     </div>
 
     <form method="POST" action="/set-language" id="language-form">

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -47,7 +47,7 @@
     </div>
 
     <div class="footer">
-        <p>Wireguard Panel by <a href="https://github.com/Azumi67" target="_blank">Azumi</a></p>
+        <p>Wireguard Panel by <a href="https://github.com/arianking8585" target="_blank">arianking8585</a></p>
     </div>
 
     <form method="POST" action="/set-language" id="language-form">

--- a/src/templates/sidebar-fa.html
+++ b/src/templates/sidebar-fa.html
@@ -22,8 +22,8 @@
         </ul>
 
         <div class="sidebar-footer">
-                <a href="https://github.com/Azumi67" target="_blank" class="github-link">
-                        <i class="fab fa-github"></i> Azumi67 GitHub
+                <a href="https://github.com/arianking8585" target="_blank" class="github-link">
+                        <i class="fab fa-github"></i> arianking8585 GitHub
                 </a>
                 <form method="POST" action="/set-language" id="language-form">
                         <select name="language" class="language-selector"

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -25,8 +25,8 @@
         </ul>
 
         <div class="sidebar-footer">
-                <a href="https://github.com/Azumi67" target="_blank" class="github-link">
-                        <i class="fab fa-github"></i> Azumi67 GitHub
+                <a href="https://github.com/arianking8585" target="_blank" class="github-link">
+                        <i class="fab fa-github"></i> arianking8585 GitHub
                 </a>
                 <form method="POST" action="/set-language" id="language-form">
                         <select name="language" class="language-selector" onchange="document.getElementById('language-form').submit()">

--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -78,7 +78,7 @@
         </div>
 
         <footer class="footer">
-            <a href="https://github.com/Azumi67" target="_blank" class="github-link">
+            <a href="https://github.com/arianking8585" target="_blank" class="github-link">
                 <i class="fa-brands fa-github"></i> GitHub
             </a>
         </footer>


### PR DESCRIPTION
## Summary
- update install commands in README files to use `arianking8585/Wireguard-panel`
- switch repository URL in helper scripts
- swap GitHub links in templates to new username

## Testing
- `python3 -m py_compile $(find src -name '*.py')`
- `shellcheck download.sh src/setup.sh short_link.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e21b6237c832e810278d1ab8985bb